### PR TITLE
feat: Add input validation for guess length in GuessInput component

### DIFF
--- a/src/components/GuessInput/GuessInput.jsx
+++ b/src/components/GuessInput/GuessInput.jsx
@@ -8,6 +8,10 @@ function GuessInput() {
   function handleSubmit(event) {
     event.preventDefault();
 
+    if (guess.length !== 5) {
+      window.alert("Please enter exactly 5 characters 🧐");
+    }
+
     setGuess("");
   }
 
@@ -15,6 +19,9 @@ function GuessInput() {
     <form className="guess-input-wrapper" onSubmit={handleSubmit}>
       <label htmlFor="guess-input">Enter guess:</label>
       <input
+        required
+        minLength={5}
+        maxLength={5}
         id="guess-input"
         type="text"
         value={guess}


### PR DESCRIPTION
Ensure that the user enters exactly 5 characters before submitting the guess form to prevent errors in the game.